### PR TITLE
allow binary topics in pub/sub

### DIFF
--- a/NNanomsg/NanoMsgSocketOptions.cs
+++ b/NNanomsg/NanoMsgSocketOptions.cs
@@ -67,12 +67,16 @@ namespace NNanomsg
 
         public static void SetString(int socket, SocketOptionLevel level, SocketOption opts, string value)
         {
+            var bs = Encoding.UTF8.GetBytes(value);
+            SetBytes(socket, level, opts, bs);
+        }
+        public static void SetBytes(int socket, SocketOptionLevel level, SocketOption opts, byte[] bs)
+        {
             unsafe
             {
-                var bs = Encoding.UTF8.GetBytes(value);
                 fixed (byte* pBs = bs)
                 {
-                    int result = Interop.nn_setsockopt(socket, (int) level, (int) opts, new IntPtr(pBs), bs.Length);
+                    int result = Interop.nn_setsockopt(socket, (int)level, (int)opts, new IntPtr(pBs), bs.Length);
                     if (result != 0)
                         throw new NanomsgException(string.Format("nn_setsockopt {0}", opts));
                 }

--- a/NNanomsg/Protocols/SubscribeSocket.cs
+++ b/NNanomsg/Protocols/SubscribeSocket.cs
@@ -10,10 +10,18 @@ namespace NNanomsg.Protocols
         {
             NanomsgSocketOptions.SetString(SocketID, SocketOptionLevel.Subscribe, SocketOption.SUB_SUBSCRIBE, topic);
         }
+        public void Subscribe(byte[] topic)
+        {
+            NanomsgSocketOptions.SetBytes(SocketID, SocketOptionLevel.Subscribe, SocketOption.SUB_SUBSCRIBE, topic);
+        }
 
         public void Unsubscribe(string topic)
         {
             NanomsgSocketOptions.SetString(SocketID, SocketOptionLevel.Subscribe, SocketOption.SUB_SUBSCRIBE, topic);
+        }
+        public void Unsubscribe(byte[] topic)
+        {
+            NanomsgSocketOptions.SetBytes(SocketID, SocketOptionLevel.Subscribe, SocketOption.SUB_SUBSCRIBE, topic);
         }
 
         #region Connect


### PR DESCRIPTION
In PUBSUB protocol, pub currently requires the topic to be in binary (it's prepended to the binary datagram). This changeset provides sub/unsub methods that take a binary topic.
