### PR TITLE
Simpler socket removal

### DIFF
--- a/NNanomsg/Listener.cs
+++ b/NNanomsg/Listener.cs
@@ -47,9 +47,9 @@ namespace NNanomsg
             {
                 if (_sockets[i] == s)
                 {
-                    Array.Copy(_sockets, i + 1, _sockets, i, _ct - i - 1);
-                    Array.Copy(_results, i + 1, _results, i, _ct - i - 1);
-                    Array.Copy(_pollfds, i + 1, _pollfds, i, _ct - i - 1);
+                    _sockets[i] = _sockets[_ct];
+                    _results[i] = _results[_ct];
+                    _pollfds[i] = _pollfds[_ct];
                     --_ct;
                     break;
                 }


### PR DESCRIPTION
I was wondering why when removing a socket all of the sockets to to the right have to be copied over, so I came up with an alternative which is to overwrite the target socket with the last socket then decrement the count.

Would be interested to understand any technical reasons why you would opt for the former approach.